### PR TITLE
Save Kubo infrastructure terraform state file.

### DIFF
--- a/docs/installing/gcp/deploying-bosh-gcp.md
+++ b/docs/installing/gcp/deploying-bosh-gcp.md
@@ -95,7 +95,7 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
     -var prefix=\${prefix} \
     -var zone=\${zone} \
     -var subnet_ip_prefix=\${subnet_ip_prefix} \
-    -state ~/${prefix}.tfstate
+    -state /\$(basename \$(pwd))/${prefix}.tfstate
 	</p>
 	This command takes between 60 and 90 seconds to complete.
 


### PR DESCRIPTION
Write Kubo intrastructure Terraform state file to mapped "platform"
directory. This allows terraform to recovery and pickup from where it
left off in subsequent runs. This also allows the user to tear down
the environment.