### PR TITLE
Update GCP API library prerequisites.

### DIFF
--- a/docs/installing/gcp/index.md
+++ b/docs/installing/gcp/index.md
@@ -10,10 +10,17 @@ You must have the following to install CFCR on GCP:
 
 1. A user account with the Owner role in the GCP project. For more information, see the [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) topic in the GCP documentation.
 
-1. You must enable the Google Cloud Resource Manager API V2. To enable this API, perform the following steps:
+1. You must enable the following API libraries:
+
+	* Google Cloud Resource Manager API
+	* Google Cloud Resource Manager API V2 (both the original and V2 versions are required)
+	* Google Identity and Access Management (IAM) API
+
+	To enable this API, perform the following steps:
+    
 	1. Navigate to the GCP Console.
 	1. From the left-hand navigation, select **APIs & services > Library**.
-	1. Search for the **Google Cloud Resource Manager API V2** entry. If it is disabled, click the **Enable** button to enable it.
+	1. Search for each library listed above. If it is disabled, click the **Enable** button to enable it.
 
 ##Step 1: Deploy BOSH for CFCR on GCP
 


### PR DESCRIPTION
Missing GCP API libraries were encountered in a relatively new GCP
account.

The "Step 3: Deploy Bastion VM" terraform step failed as a result of
not having the API libraries readily available.

Note: Both the original (V1) and V2 versions of Google Cloud Resource
Manager API are required.