### PR TITLE
Kubo doc updates

### DIFF
--- a/docs/installing/gcp/deploying-bosh-gcp.md
+++ b/docs/installing/gcp/deploying-bosh-gcp.md
@@ -70,12 +70,12 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
 
 1. From the Google Cloud Shell, change into the home directory. Enter the following command:
 	<p class="terminal">$ cd ~</p>
-1. See the [release notes](../../overview/release-notes) for a link to the latest `kubo-deployment` release. Enter the following command, replacing `KUBO-RELEASE-URL` with the release artifact URL:
-  <p class="terminal">$ wget http<span>s:/</span>/KUBO-RELEASE-URL.tgz</p>
+1. See the [release notes](../../overview/release-notes) for a link to the latest `kubo-deployment` release. Enter the following commands, replacing `KUBO-DEPLOYMENT-RELEASE-URL` with the release artifact URL:
+  <p class="terminal">$ wget `KUBO-DEPLOYMENT-RELEASE-URL`</p>
 1. Expand the tarball. Enter the following command, replacing `KUBO-RELEASE` with the name of the file you downloaded in the previous step:
-  <p class="terminal">$ tar -xvf KUBO-RELEASE.tgz</p>
+  <p class="terminal">$ tar -xvf $(basename `KUBO-DEPLOYMENT-RELEASE-URL`)</p>
 1. Change into the directory that contains the GCP Terraform templates. Enter the following command:
-	<p class="terminal">$ cd ~/kubo-deployment/docs/terraform/gcp/platform</p>
+	<p class="terminal">$ cd ~/$(basename `KUBO-DEPLOYMENT-RELEASE-URL` .tgz)/kubo-deployment/docs/terraform/gcp/platform</p>
 1. Initialize the Terraform cloud provider. Enter the following command:
 	<p class="terminal">$ docker run -i -t \
   -v \$(pwd):/\$(basename \$(pwd)) \

--- a/docs/installing/gcp/deploying-bosh-gcp.md
+++ b/docs/installing/gcp/deploying-bosh-gcp.md
@@ -50,7 +50,7 @@ Perform the following steps to set up your Google Cloud Shell environment:
 Perform the following steps to set up a GCP account for Terraform:
 
 1. From the Google Cloud Shell, create a service account for Terraform. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts create ${prefix}terraform</p>
+	<p class="terminal">$ gcloud iam service-accounts create ${prefix}terraform --display-name ${prefix}terraform</p>
 1. Create a service account key. Enter the following command:
 	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix}tf.key.json \
     --iam-account ${service_account_email}</p>


### PR DESCRIPTION
Two minor updates:
* Add "Display name" option when creating gcp service account. The resultant service command looks a bit odd without the corresponding display name as seen in the GCP console (Service account name) and corresponding `gcloud iam service-accounts list` (NAME) command.
* Provide helper commands when passed KUBO-DEPLOYMENT-RELEASE-URL. I named the replacement variable to distinguish the kubo-deployment release from the actual kubo-release.