### PR TITLE
Docs to match changes to terraform scripts

### DIFF
--- a/docs/installing/aws/deploying-bosh-aws.md
+++ b/docs/installing/aws/deploying-bosh-aws.md
@@ -89,7 +89,7 @@ Perform the following steps to deploy a bastion VM with a set of security group 
   -var region="\${region}" \
   -var zone="\${zone}" \
   -var vpc_id="\${vpc_id}" \
-  -var prefix="\${prefix}" \
+  -var prefix="\${prefix:-cfcr}" \
   -var public_subnet_ip_prefix="\${public_subnet_ip_prefix}" \
   -var private_subnet_ip_prefix="\${private_subnet_ip_prefix}" \
   -var private_key_filename="\${private_key_filename}" \

--- a/docs/installing/aws/deploying-bosh-aws.md
+++ b/docs/installing/aws/deploying-bosh-aws.md
@@ -185,7 +185,7 @@ Perform the following steps to create a new IAM user to deploy the BOSH Director
 	        {
 	            "Effect": "Allow",
 	            "Action": "iam:PassRole",
-	            "Resource": "arn:aws:iam::YOUR-ACCOUNT-ID:role/*kubo*"
+	            "Resource": "arn:aws:iam::YOUR-ACCOUNT-ID:role/*cfcr*"
 	        }
 	    ]
 	}

--- a/docs/installing/aws/routing-aws.md
+++ b/docs/installing/aws/routing-aws.md
@@ -39,7 +39,7 @@ $ export AWS_SECRET_ACCESS_KEY=dsfSDFKOSDFKOasdmasdKSADOK</p>
    -var vpc_id=\${vpc_id} \
    -var node_security_group_id=\${default_security_groups} \
    -var public_subnet_id=\${public_subnet_id} \
-   -var prefix=\${prefix} \
+   -var prefix=\${prefix:-cfcr} \
    -state=\${kubo_terraform_state}</p>
 1. Set the `master_target_pool` and `kubernetes_master_host` environment variables with the following commands:
 	<p class="terminal">$ export master_target_pool=\$(terraform output -state=${kubo_terraform_state} kubo_master_target_pool) 

--- a/docs/installing/deploying-cfcr.md
+++ b/docs/installing/deploying-cfcr.md
@@ -23,7 +23,7 @@ Follow the steps for your IaaS:
 	1. Change into your Terraform working directory with the following command:
 		<p class="terminal">$ cd ~/kubo-deployment/docs/terraform/aws/platform</p>
 	1. SSH onto the bastion VM with the following command:
-		<p class="terminal">$ ssh -i ~/deployer.pem ubuntu@$(terraform output bosh-bastion-ip)</p>
+		<p class="terminal">$ ssh -i ~/deployer.pem ubuntu@$(terraform output -state ~/terraform.tfstate bosh-bastion-ip)</p>
 * **vSphere or OpenStack**: If you deployed BOSH for CFCR from a bastion VM, SSH into the VM. Otherwise, navigate to the CFCR environment on your local machine.
 
 ##(Optional) Step 2: Configure Proxy Access

--- a/docs/installing/gcp/deploying-bosh-gcp.md
+++ b/docs/installing/gcp/deploying-bosh-gcp.md
@@ -39,7 +39,7 @@ Perform the following steps to set up your Google Cloud Shell environment:
 1. Set your zone where you want to deploy CFCR as an environment variable. For example:
 	<p class="terminal">$ export zone=us-west1-a</p>
 1. Set your service account email address as an environment variable. Enter the following command:
-	<p class="terminal">$ export service_account_email=\${prefix}-terraform@\${project_id}.iam.gserviceaccount.com</p>
+	<p class="terminal">$ export service_account_email=\${prefix:-cfcr}-terraform@\${project_id}.iam.gserviceaccount.com</p>
 1. Configure `gcloud` to use your zone. Enter the following command:
 	<p class="terminal">$ gcloud config set compute/zone ${zone}</p>
 1. Configure `gcloud` to use your region. Enter the following command:
@@ -50,16 +50,16 @@ Perform the following steps to set up your Google Cloud Shell environment:
 Perform the following steps to set up a GCP account for Terraform:
 
 1. From the Google Cloud Shell, create a service account for Terraform. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts create ${prefix}-terraform --display-name ${prefix}-terraform</p>
+	<p class="terminal">$ gcloud iam service-accounts create ${prefix:-cfcr}-terraform --display-name ${prefix:-cfcr}-terraform</p>
 1. Create a service account key. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix}-tf.key.json \
+	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix:-cfcr}-tf.key.json \
     --iam-account ${service_account_email}</p>
 1. Grant the new service account owner access to your project. Enter the following command:
 	<p class="terminal">$ gcloud projects add-iam-policy-binding \${project_id} \
 	  --member serviceAccount:${service_account_email} \
 	  --role roles/owner</p>
 1. Set your service account key as an environment variable. Enter the following command:
-	<p class="terminal">$ export GOOGLE_CREDENTIALS=\$(cat ~/\${prefix}-tf.key.json)</p>
+	<p class="terminal">$ export GOOGLE_CREDENTIALS=\$(cat ~/\${prefix:-cfcr}-tf.key.json)</p>
 
 	If Terraform refuses to accept the JSON key as the content of `GOOGLE_CREDENTIALS`, provide the path to the file instead, using `GOOGLE_APPLICATION_CREDENTIALS`. Enter the following command:
 		<p class="terminal">$ export GOOGLE_APPLICATION_CREDENTIALS=~/terraform.key.json</p>
@@ -92,10 +92,10 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
     -var projectid=\${project_id} \
     -var network=\${network} \
     -var region=\${region} \
-    -var prefix=\${prefix} \
+    -var prefix=\${prefix:-cfcr} \
     -var zone=\${zone} \
     -var subnet_ip_prefix=\${subnet_ip_prefix} \
-    -state /\$(basename \$(pwd))/${prefix}.tfstate
+    -state /\$(basename \$(pwd))/${prefix:-cfcr}.tfstate
 	</p>
 	This command takes between 60 and 90 seconds to complete.
 
@@ -103,7 +103,7 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
 		To preview the Terraform execution plan before applying it, run `plan` instead of `apply`.
 
 1. Copy the service account key to the newly created bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute scp ~/\${prefix}-tf.key.json "\${prefix}-bosh-bastion":./terraform.key.json --zone \${zone}</p>
+	<p class="terminal">$ gcloud compute scp ~/\${prefix:-cfcr}-tf.key.json "\${prefix:-cfcr}-bosh-bastion":./terraform.key.json --zone \${zone}</p>
 	If prompted to create SSH keys, enter `Y` and use an empty passphrase.
 
 ##Step 4: Generate BOSH Configuration
@@ -111,7 +111,7 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
 Perform the following steps to generate the configuration for your BOSH Director:
 
 1. From the Google Cloud Shell, SSH onto the bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute ssh "${prefix}-bosh-bastion" --zone ${zone}</p>
+	<p class="terminal">$ gcloud compute ssh "${prefix:-cfcr}-bosh-bastion" --zone ${zone}</p>
 1. Change into the root of the `kubo-deployment` repo. Enter the following command:
 	<p class="terminal">$ cd /share/kubo-deployment</p>
 1. Set three environment variables with the following commands:

--- a/docs/installing/gcp/deploying-bosh-gcp.md
+++ b/docs/installing/gcp/deploying-bosh-gcp.md
@@ -39,7 +39,7 @@ Perform the following steps to set up your Google Cloud Shell environment:
 1. Set your zone where you want to deploy CFCR as an environment variable. For example:
 	<p class="terminal">$ export zone=us-west1-a</p>
 1. Set your service account email address as an environment variable. Enter the following command:
-	<p class="terminal">$ export service_account_email=\${prefix}terraform@\${project_id}.iam.gserviceaccount.com</p>
+	<p class="terminal">$ export service_account_email=\${prefix}-terraform@\${project_id}.iam.gserviceaccount.com</p>
 1. Configure `gcloud` to use your zone. Enter the following command:
 	<p class="terminal">$ gcloud config set compute/zone ${zone}</p>
 1. Configure `gcloud` to use your region. Enter the following command:
@@ -50,16 +50,16 @@ Perform the following steps to set up your Google Cloud Shell environment:
 Perform the following steps to set up a GCP account for Terraform:
 
 1. From the Google Cloud Shell, create a service account for Terraform. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts create ${prefix}terraform --display-name ${prefix}terraform</p>
+	<p class="terminal">$ gcloud iam service-accounts create ${prefix}-terraform --display-name ${prefix}-terraform</p>
 1. Create a service account key. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix}tf.key.json \
+	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix}-tf.key.json \
     --iam-account ${service_account_email}</p>
 1. Grant the new service account owner access to your project. Enter the following command:
 	<p class="terminal">$ gcloud projects add-iam-policy-binding \${project_id} \
 	  --member serviceAccount:${service_account_email} \
 	  --role roles/owner</p>
 1. Set your service account key as an environment variable. Enter the following command:
-	<p class="terminal">$ export GOOGLE_CREDENTIALS=\$(cat ~/\${prefix}tf.key.json)</p>
+	<p class="terminal">$ export GOOGLE_CREDENTIALS=\$(cat ~/\${prefix}-tf.key.json)</p>
 
 	If Terraform refuses to accept the JSON key as the content of `GOOGLE_CREDENTIALS`, provide the path to the file instead, using `GOOGLE_APPLICATION_CREDENTIALS`. Enter the following command:
 		<p class="terminal">$ export GOOGLE_APPLICATION_CREDENTIALS=~/terraform.key.json</p>
@@ -103,7 +103,7 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
 		To preview the Terraform execution plan before applying it, run `plan` instead of `apply`.
 
 1. Copy the service account key to the newly created bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute scp ~/\${prefix}tf.key.json "\${prefix}bosh-bastion":./terraform.key.json --zone \${zone}</p>
+	<p class="terminal">$ gcloud compute scp ~/\${prefix}-tf.key.json "\${prefix}-bosh-bastion":./terraform.key.json --zone \${zone}</p>
 	If prompted to create SSH keys, enter `Y` and use an empty passphrase.
 
 ##Step 4: Generate BOSH Configuration
@@ -111,7 +111,7 @@ Perform the following steps to deploy a bastion VM with a set of firewall rules 
 Perform the following steps to generate the configuration for your BOSH Director:
 
 1. From the Google Cloud Shell, SSH onto the bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute ssh "${prefix}bosh-bastion" --zone ${zone}</p>
+	<p class="terminal">$ gcloud compute ssh "${prefix}-bosh-bastion" --zone ${zone}</p>
 1. Change into the root of the `kubo-deployment` repo. Enter the following command:
 	<p class="terminal">$ cd /share/kubo-deployment</p>
 1. Set three environment variables with the following commands:
@@ -166,7 +166,7 @@ Perform the following steps to deploy a BOSH Director from the bastion VM:
   <p class="terminal">$ bosh environment</p>
   BOSH provides information about your environment. For example:
   <p class="terminal">Using environment '10.0.1.252' as client 'bosh_admin'<br>
-Name      my-kubobosh
+Name      my-kubo-bosh
 UUID      a7e779dd-f9cc-43f2-b491-7358556bc730
 Version   264.1.0 (00000000)
 CPI       google_cpi

--- a/docs/installing/gcp/routing-gcp.md
+++ b/docs/installing/gcp/routing-gcp.md
@@ -24,7 +24,7 @@ $ export zone=us-west1-a
 $ export network=kubo-network
 $ export subnet_ip_prefix="10.0.1"</p>
 1. SSH onto the bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute ssh "${prefix}-bosh-bastion" --zone ${zone}</p>
+	<p class="terminal">$ gcloud compute ssh "${prefix:-cfcr}-bosh-bastion" --zone ${zone}</p>
 1. Set the `kubo_env_name` environment variable to `kubo`. Enter the following command:
 	<p class="terminal">$ export kubo_env_name=kubo</p> 
 

--- a/docs/installing/gcp/routing-gcp.md
+++ b/docs/installing/gcp/routing-gcp.md
@@ -39,7 +39,7 @@ $ export kubo_terraform_state=${state_dir}/terraform.tfstate</p>
     -var network=\${network} \
     -var projectid=\${project_id} \
     -var region=\${region} \
-    -var prefix=\${prefix} \
+    -var prefix=\${prefix:-cfcr} \
     -var ip_cidr_range="\${subnet_ip_prefix}.0/24" \
     -state=\${kubo_terraform_state}</p>
 1. Set the master target pool from the outputted Terraform state file as an environment variable. Enter the following command:

--- a/docs/installing/gcp/routing-gcp.md
+++ b/docs/installing/gcp/routing-gcp.md
@@ -20,7 +20,9 @@ If you have started a new Google Cloud Shell session, perform the following step
 
 1. Set the prefix and zone from the [Step 1: Set Up Your Shell Environment](deploying-bosh-gcp/#step-1-set-up-your-shell-environment) section of the [Deploying BOSH for CFCR on GCP](https://docs-kubo.cfapps.io/installing/gcp/deploying-bosh-gcp/) topic as environment variables. For example:
 	<p class="terminal">$ export prefix=my-kubo
-$ export zone=us-west1-a</p>
+$ export zone=us-west1-a
+$ export network=kubo-network
+$ export subnet_ip_prefix="10.0.1"</p>
 1. SSH onto the bastion VM. Enter the following command:
 	<p class="terminal">$ gcloud compute ssh "${prefix}-bosh-bastion" --zone ${zone}</p>
 1. Set the `kubo_env_name` environment variable to `kubo`. Enter the following command:

--- a/docs/installing/gcp/routing-gcp.md
+++ b/docs/installing/gcp/routing-gcp.md
@@ -22,7 +22,7 @@ If you have started a new Google Cloud Shell session, perform the following step
 	<p class="terminal">$ export prefix=my-kubo
 $ export zone=us-west1-a</p>
 1. SSH onto the bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute ssh "${prefix}bosh-bastion" --zone ${zone}</p>
+	<p class="terminal">$ gcloud compute ssh "${prefix}-bosh-bastion" --zone ${zone}</p>
 1. Set the `kubo_env_name` environment variable to `kubo`. Enter the following command:
 	<p class="terminal">$ export kubo_env_name=kubo</p> 
 
@@ -43,7 +43,7 @@ $ export kubo_terraform_state=${state_dir}/terraform.tfstate</p>
     -var ip_cidr_range="\${subnet_ip_prefix}.0/24" \
     -state=\${kubo_terraform_state}</p>
 1. Set the master target pool from the outputted Terraform state file as an environment variable. Enter the following command:
-	<p class="terminal">$ export master_target_pool=\$(terraform output -state=\${kubo_terraform_state} kubo_master_target_pool)</p>
+	<p class="terminal">$ export master_target_pool=\$(terraform output -state=\${kubo_terraform_state} cfcr_master_target_pool)</p>
 1. Set the Kubernetes master host from the outputted Terraform state file as an environment variable. Enter the following command:
 	<p class="terminal">$ export kubernetes_master_host=\$(terraform output -state=\${kubo_terraform_state} master_lb_ip_address)</p>
 1. Update the CFCR environment by running the `set_iaas_routing` script. Enter the following command:


### PR DESCRIPTION
As part of CFCR story #154882173 we changed the resource names created by terraform to contain the word `cfcr` instead of `kubo`.  We are also making the use of a hyphen following the prefix consistent.

To allow for empty `prefix` variable, default values are provided wherever `${prefix}` is used.

Also fixes bugs related to:
* missing path to `terraform.tfstate` file.
* missing variables to be set when setting up environment to configure GCP IaaS routing

**Please wait** until a kubo-deployment release containing accepted story #154882173 is cut before merging into master.