### PR TITLE
Routing has to be done prior to deploying bosh

### DIFF
--- a/docs/installing/gcp/index.md
+++ b/docs/installing/gcp/index.md
@@ -22,15 +22,15 @@ You must have the following to install CFCR on GCP:
 	1. From the left-hand navigation, select **APIs & services > Library**.
 	1. Search for each library listed above. If it is disabled, click the **Enable** button to enable it.
 
-##Step 1: Deploy BOSH for CFCR on GCP
-
-Pave your infrastructure and deploy the BOSH Director for CFCR by following the procedures in the [Deploying BOSH for CFCR on GCP](deploying-bosh-gcp/) topic.
-
-##Step 2: Configure Routing
+##Step 1: Configure Routing
 
 Configure your load balancers for CFCR by following the procedures in the [Configuring IaaS Routing for GCP](routing-gcp/) topic.
 
 If you want to use Cloud Foundry for routing instead of IaaS load balancers, see the [Configuring Cloud Foundry Routing](../cf-routing/) topic.
+
+##Step 2: Deploy BOSH for CFCR on GCP
+
+Pave your infrastructure and deploy the BOSH Director for CFCR by following the procedures in the [Deploying BOSH for CFCR on GCP](deploying-bosh-gcp/) topic.
 
 ##Step 3: Deploy CFCR
 


### PR DESCRIPTION
The cloud config is now set in the deploy bosh step.  The cloud config requires information about the load balancer to be deployed successfully.

The configure routing step should occur prior to deploying bosh.

(docs team, you'll also have to fix up the introduction to the Configure Routing section as it currently implies that the user has already done the deploy bosh step)