### PR TITLE
Ensure GCP infrastructure is paved before routing

### DIFF
--- a/docs/installing/aws/deploying-bosh-aws.md
+++ b/docs/installing/aws/deploying-bosh-aws.md
@@ -108,7 +108,7 @@ Perform the following steps to deploy a bastion VM with a set of security group 
 ##Step 3: Generate CFCR Configuration
 
 1. SSH onto the bastion VM. Enter the following command:
-	<p class="terminal">$ ssh -i ~/deployer.pem ubuntu@\$(terraform output -state=\${kubo_terraform_state} bosh-bastion-ip)</p>
+	<p class="terminal">$ ssh -i "${private_key_filename}" ubuntu@\$(terraform output -state=\${kubo_terraform_state} bosh-bastion-ip)</p>
 1. Change into the root of the `kubo-deployment` repo. Enter the following command:
 	<p class="terminal">$ cd /share/kubo-deployment</p> 
 1. Set three Kubo environment variables with the following commands:
@@ -219,6 +219,9 @@ Perform the following steps to deploy a BOSH Director from the bastion VM:
 
 		!!! note
 			Subsequent runs of `deploy_bosh` will use `creds.yml` and `state.json` to apply changes to the BOSH environment.
+
+1. Target the bosh environment. Enter the following command:
+	<p class="terminal">$ BOSH_ENV=${kubo_env_path} source /share/kubo-deployment/bin/set_bosh_environment</p>
 
 If you plan to use IaaS routing for CFCR, continue to [Configure IaaS Routing for AWS](routing-aws/).
 

--- a/docs/installing/gcp/deploying-bosh-gcp.md
+++ b/docs/installing/gcp/deploying-bosh-gcp.md
@@ -2,140 +2,25 @@
 
 This topic describes how to deploy BOSH for Cloud Foundry Container Runtime (CFCR) on Google Cloud Platform (GCP). Installing CFCR requires deploying a BOSH Director. 
 
-In the procedures below, you use [Terraform](https://www.terraform.io/docs/) to pave your infrastructure and create a bastion VM. Then you deploy a BOSH Director from the bastion VM. 
+In the procedures below, you deploy a BOSH Director from the bastion VM.  Refer to the [Paving Infrastructure on GCP](paving-infrastructure-gcp/) topic for how to create the bastion VM.
 
-!!! note
-	CFCR was formerly known as Kubo, and many CFCR assets described in this topic still use the Kubo name.
+##(Optional) Step 1: Set Up Your Environment
 
-##Step 1: Set Up Your Shell Environment
+If you are still working in the same Google Cloud Shell session from the [Paving Infrastructure on GCP](paving-infrastructure-gcp/) topic, skip to [Step 2: Deploy BOSH Director](#step-2-deploy-bosh-director).
 
-Perform the following steps to set up your Google Cloud Shell environment: 
+If you have started a new Google Cloud Shell session, perform the following steps:
 
-1. Log in to the GCP Console.
-1. From the left-hand navigation, click **VPC network**.
-1. Click **Create VPC Network**.
-
-	!!! tip
-		If you plan to use [Cloud Foundry to handle routing](../cf-routing.html) for CFCR, do not create a new network. Instead, deploy CFCR in the same network as Cloud Foundry.
-
-1. Enter a name for your network, such as `kubo-network`.
-1. The form will force you to create a subnet for the VPC network. After the VPC has been created, you can delete this subnet.
-1. Click **Create**.
-1. Open the Google Cloud Shell by clicking the `>_` icon in the upper right of the GCP Console.
-
-	!!!note
-		Execute all of the commands in this topic from the Google Cloud Shell, not from your local machine.
-
-1. If you are deploying CFCR more than once, you must set a unique prefix for every installation. Export an environment variable in the Google Cloud Shell to set a prefix for your CFCR installation. Use letters and dashes only. For example:
-	<p class="terminal">$ export prefix=my-kubo</p>
-1. Set the name of your GCP network as an environment variable. For example:
-	<p class="terminal">$ export network=kubo-network</p>
-1. Set your subnet prefix as an environment variable. You must configure a CIDR range with a mask that is 24 bits long. A CIDR range of `10.0.1.0/24` would result in a subnet prefix of `10.0.1`. For example:
-	<p class="terminal">$ export subnet_ip_prefix="10.0.1"</p>
-1. Set your project ID as an environment variable using `gcloud`. Enter the following command:
-	<p class="terminal">$ export project_id=$(gcloud config get-value project)</p>
-1. Set your region where you want to deploy CFCR as an environment variable. For example:
-	<p class="terminal">$ export region=us-west1</p>
-1. Set your zone where you want to deploy CFCR as an environment variable. For example:
-	<p class="terminal">$ export zone=us-west1-a</p>
-1. Set your service account email address as an environment variable. Enter the following command:
-	<p class="terminal">$ export service_account_email=\${prefix:-cfcr}-terraform@\${project_id}.iam.gserviceaccount.com</p>
-1. Configure `gcloud` to use your zone. Enter the following command:
-	<p class="terminal">$ gcloud config set compute/zone ${zone}</p>
-1. Configure `gcloud` to use your region. Enter the following command:
-	<p class="terminal">$ gcloud config set compute/region ${region}</p>
-
-##Step 2: Set Up a GCP Account for Terraform
-
-Perform the following steps to set up a GCP account for Terraform:
-
-1. From the Google Cloud Shell, create a service account for Terraform. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts create ${prefix:-cfcr}-terraform --display-name ${prefix:-cfcr}-terraform</p>
-1. Create a service account key. Enter the following command:
-	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix:-cfcr}-tf.key.json \
-    --iam-account ${service_account_email}</p>
-1. Grant the new service account owner access to your project. Enter the following command:
-	<p class="terminal">$ gcloud projects add-iam-policy-binding \${project_id} \
-	  --member serviceAccount:${service_account_email} \
-	  --role roles/owner</p>
-1. Set your service account key as an environment variable. Enter the following command:
-	<p class="terminal">$ export GOOGLE_CREDENTIALS=\$(cat ~/\${prefix:-cfcr}-tf.key.json)</p>
-
-	If Terraform refuses to accept the JSON key as the content of `GOOGLE_CREDENTIALS`, provide the path to the file instead, using `GOOGLE_APPLICATION_CREDENTIALS`. Enter the following command:
-		<p class="terminal">$ export GOOGLE_APPLICATION_CREDENTIALS=~/${prefix:-cfcr}-tf.key.json</p>
-
-##Step 3: Deploy Bastion VM
-
-Perform the following steps to deploy a bastion VM with a set of firewall rules that secures access to the CFCR deployment:
-
-1. From the Google Cloud Shell, change into the home directory. Enter the following command:
-	<p class="terminal">$ cd ~</p>
-1. See the [release notes](../../overview/release-notes) for a link to the latest `kubo-deployment` release. Enter the following commands, replacing `KUBO-DEPLOYMENT-RELEASE-URL` with the release artifact URL:
-  <p class="terminal">$ wget `KUBO-DEPLOYMENT-RELEASE-URL`</p>
-1. Expand the tarball. Enter the following command, replacing `KUBO-DEPLOYMENT-RELEASE-URL` with the name of the file you downloaded in the previous step:
-  <p class="terminal">$ tar -xvf $(basename `KUBO-DEPLOYMENT-RELEASE-URL`)</p>
-1. Change into the directory that contains the GCP Terraform templates. Enter the following command:
-	<p class="terminal">$ cd ~/$(basename `KUBO-DEPLOYMENT-RELEASE-URL` .tgz)/kubo-deployment/docs/terraform/gcp/platform</p>
-1. Initialize the Terraform cloud provider. Enter the following command:
-	<p class="terminal">$ docker run -i -t \
-  -v \$(pwd):/\$(basename \$(pwd)) \
-  -w /\$(basename $(pwd)) \
-  hashicorp/terraform:light init</p>
-1. Create the bastion and other resources. Enter the following command:
-	<p class="terminal">$ docker run -i -t \
-  -e CHECKPOINT_DISABLE=1 \
-  -e "GOOGLE_CREDENTIALS=\${GOOGLE_CREDENTIALS}" \
-  -v \$(pwd):/\$(basename \$(pwd)) \
-  -w /\$(basename \$(pwd)) \
-  hashicorp/terraform:light apply \
-    -var service_account_email=\${service_account_email} \
-    -var projectid=\${project_id} \
-    -var network=\${network} \
-    -var region=\${region} \
-    -var prefix=\${prefix:-cfcr} \
-    -var zone=\${zone} \
-    -var subnet_ip_prefix=\${subnet_ip_prefix} \
-    -state /\$(basename \$(pwd))/${prefix:-cfcr}.tfstate
-	</p>
-	This command takes between 60 and 90 seconds to complete.
-
-	!!! tip
-		To preview the Terraform execution plan before applying it, run `plan` instead of `apply`.
-
-1. Copy the service account key to the newly created bastion VM. Enter the following command:
-	<p class="terminal">$ gcloud compute scp ~/\${prefix:-cfcr}-tf.key.json "\${prefix:-cfcr}-bosh-bastion":./terraform.key.json --zone \${zone}</p>
-	If prompted to create SSH keys, enter `Y` and use an empty passphrase.
-
-##Step 4: Generate BOSH Configuration
-
-Perform the following steps to generate the configuration for your BOSH Director:
-
-1. From the Google Cloud Shell, SSH onto the bastion VM. Enter the following command:
+1. Set the prefix and zone from the [Step 1: Set Up Your Shell Environment](paving-infrastructure-gcp/#step-1-set-up-your-shell-environment) section of the [Paving Infrastructure on GCP](https://docs-kubo.cfapps.io/installing/gcp/paving-infrastructure-gcp/) topic as environment variables. For example:
+	<p class="terminal">$ export prefix=my-kubo
+$ export zone=us-west1-a
+$ export network=kubo-network
+$ export subnet_ip_prefix="10.0.1"</p>
+1. SSH onto the bastion VM. Enter the following command:
 	<p class="terminal">$ gcloud compute ssh "${prefix:-cfcr}-bosh-bastion" --zone ${zone}</p>
-1. Change into the root of the `kubo-deployment` repo. Enter the following command:
-	<p class="terminal">$ cd /share/kubo-deployment</p>
-1. Set three environment variables with the following commands:
-	<p class="terminal">$ export kubo_envs=~/kubo-env
-$ export kubo_env_name=kubo
-$ export kubo_env_path="\${kubo_envs}/\${kubo_env_name}"</p>
+1. Set the `kubo_env_name` environment variable to `kubo`. Enter the following command:
+	<p class="terminal">$ export kubo_env_name=kubo</p> 
 
-	!!! note
-		`kubo_env_path` points to the directory containing the CFCR configuration. Later topics will refer to this path as `KUBO_ENV`.
-
-1. Make a new directory path with the following command:
-	<p class="terminal">$ mkdir -p "${kubo_envs}"</p>
-1. Generate a CFCR configuration template. Enter the following command:
-	<p class="terminal">$ ./bin/generate_env_config "${kubo_envs}" ${kubo_env_name} gcp</p>
-1. Execute the `update_gcp_env` script to apply the default network settings configured during the infrastructure paving to the template. Enter the following command:
-	<p class="terminal">$ /usr/bin/update_gcp_env "${kubo_env_path}/director.yml"</p>
-
-	!!! tip
-		You can directly edit the configuration file located at `${kubo_env_path}/director.yml`.
-
-	!!! warning
-		If you want to configure Cloud Foundry to handle routing for CFCR, **do not continue to the next section**. Perform the procedures in [Configuring Cloud Foundry Routing](../cf-routing/) before deploying the BOSH Director. 
-
-##Step 5: Deploy BOSH Director
+##Step 2: Deploy BOSH Director
 
 Perform the following steps to deploy a BOSH Director from the bastion VM:
 
@@ -156,7 +41,7 @@ Perform the following steps to deploy a BOSH Director from the bastion VM:
 		!!! note
 			Subsequent runs of `deploy_bosh` will use `creds.yml` and `state.json` to apply changes to the BOSH environment.
 
-##Step 6: Access the BOSH Director
+##Step 3: Access the BOSH Director
 
 
 1. Set your environment to access the BOSH Director. Enter the following command:
@@ -177,6 +62,3 @@ Features  compiled_package_cache: disabled
 User      bosh_admin<br>
 Succeeded</p>
 
-If you plan to use IaaS routing for CFCR, continue to [Configure IaaS Routing for GCP](routing-gcp/).
-
-If you have configured Cloud Foundry routing, continue to [Deploying CFCR](../deploying-cfcr/).

--- a/docs/installing/gcp/index.md
+++ b/docs/installing/gcp/index.md
@@ -22,17 +22,21 @@ You must have the following to install CFCR on GCP:
 	1. From the left-hand navigation, select **APIs & services > Library**.
 	1. Search for each library listed above. If it is disabled, click the **Enable** button to enable it.
 
-##Step 1: Configure Routing
+##Step 1: Pave your Infrastructure
+
+Pave your infrastructure by following the procedures in the [Paving infrastructure on GCP](paving-infrastructure-gcp/) topic.
+
+##Step 2: Configure Routing
 
 Configure your load balancers for CFCR by following the procedures in the [Configuring IaaS Routing for GCP](routing-gcp/) topic.
 
 If you want to use Cloud Foundry for routing instead of IaaS load balancers, see the [Configuring Cloud Foundry Routing](../cf-routing/) topic.
 
-##Step 2: Deploy BOSH for CFCR on GCP
+##Step 3: Deploy BOSH for CFCR on GCP
 
 Pave your infrastructure and deploy the BOSH Director for CFCR by following the procedures in the [Deploying BOSH for CFCR on GCP](deploying-bosh-gcp/) topic.
 
-##Step 3: Deploy CFCR
+##Step 4: Deploy CFCR
 
 After deploying BOSH for CFCR and configuring your load balancers, continue to the [Deploying CFCR](../deploying-cfcr/) topic to finish the CFCR installation.
 

--- a/docs/installing/gcp/paving-infrastructure-gcp.md
+++ b/docs/installing/gcp/paving-infrastructure-gcp.md
@@ -1,0 +1,134 @@
+
+In the procedures below, you use [Terraform](https://www.terraform.io/docs/) to pave your infrastructure and create a bastion VM. Then you deploy a BOSH Director from the bastion VM. 
+
+!!! note
+	CFCR was formerly known as Kubo, and many CFCR assets described in this topic still use the Kubo name.
+
+##Step 1: Set Up Your Shell Environment
+
+Perform the following steps to set up your Google Cloud Shell environment: 
+
+1. Log in to the GCP Console.
+1. From the left-hand navigation, click **VPC network**.
+1. Click **Create VPC Network**.
+
+	!!! tip
+		If you plan to use [Cloud Foundry to handle routing](../cf-routing.html) for CFCR, do not create a new network. Instead, deploy CFCR in the same network as Cloud Foundry.
+
+1. Enter a name for your network, such as `kubo-network`.
+1. The form will force you to create a subnet for the VPC network. After the VPC has been created, you can delete this subnet.
+1. Click **Create**.
+1. Open the Google Cloud Shell by clicking the `>_` icon in the upper right of the GCP Console.
+
+	!!!note
+		Execute all of the commands in this topic from the Google Cloud Shell, not from your local machine.
+
+1. If you are deploying CFCR more than once, you must set a unique prefix for every installation. Export an environment variable in the Google Cloud Shell to set a prefix for your CFCR installation. Use letters and dashes only. For example:
+	<p class="terminal">$ export prefix=my-kubo</p>
+1. Set the name of your GCP network as an environment variable. For example:
+	<p class="terminal">$ export network=kubo-network</p>
+1. Set your subnet prefix as an environment variable. You must configure a CIDR range with a mask that is 24 bits long. A CIDR range of `10.0.1.0/24` would result in a subnet prefix of `10.0.1`. For example:
+	<p class="terminal">$ export subnet_ip_prefix="10.0.1"</p>
+1. Set your project ID as an environment variable using `gcloud`. Enter the following command:
+	<p class="terminal">$ export project_id=$(gcloud config get-value project)</p>
+1. Set your region where you want to deploy CFCR as an environment variable. For example:
+	<p class="terminal">$ export region=us-west1</p>
+1. Set your zone where you want to deploy CFCR as an environment variable. For example:
+	<p class="terminal">$ export zone=us-west1-a</p>
+1. Set your service account email address as an environment variable. Enter the following command:
+	<p class="terminal">$ export service_account_email=\${prefix:-cfcr}-terraform@\${project_id}.iam.gserviceaccount.com</p>
+1. Configure `gcloud` to use your zone. Enter the following command:
+	<p class="terminal">$ gcloud config set compute/zone ${zone}</p>
+1. Configure `gcloud` to use your region. Enter the following command:
+	<p class="terminal">$ gcloud config set compute/region ${region}</p>
+
+##Step 2: Set Up a GCP Account for Terraform
+
+Perform the following steps to set up a GCP account for Terraform:
+
+1. From the Google Cloud Shell, create a service account for Terraform. Enter the following command:
+	<p class="terminal">$ gcloud iam service-accounts create ${prefix:-cfcr}-terraform --display-name ${prefix:-cfcr}-terraform</p>
+1. Create a service account key. Enter the following command:
+	<p class="terminal">$ gcloud iam service-accounts keys create ~/${prefix:-cfcr}-tf.key.json \
+    --iam-account ${service_account_email}</p>
+1. Grant the new service account owner access to your project. Enter the following command:
+	<p class="terminal">$ gcloud projects add-iam-policy-binding \${project_id} \
+	  --member serviceAccount:${service_account_email} \
+	  --role roles/owner</p>
+1. Set your service account key as an environment variable. Enter the following command:
+	<p class="terminal">$ export GOOGLE_CREDENTIALS=\$(cat ~/\${prefix:-cfcr}-tf.key.json)</p>
+
+	If Terraform refuses to accept the JSON key as the content of `GOOGLE_CREDENTIALS`, provide the path to the file instead, using `GOOGLE_APPLICATION_CREDENTIALS`. Enter the following command:
+		<p class="terminal">$ export GOOGLE_APPLICATION_CREDENTIALS=~/${prefix:-cfcr}-tf.key.json</p>
+
+##Step 3: Deploy Bastion VM
+
+Perform the following steps to deploy a bastion VM with a set of firewall rules that secures access to the CFCR deployment:
+
+1. From the Google Cloud Shell, change into the home directory. Enter the following command:
+	<p class="terminal">$ cd ~</p>
+1. See the [release notes](../../overview/release-notes) for a link to the latest `kubo-deployment` release. Enter the following commands, replacing `KUBO-DEPLOYMENT-RELEASE-URL` with the release artifact URL:
+  <p class="terminal">$ wget `KUBO-DEPLOYMENT-RELEASE-URL`</p>
+1. Expand the tarball. Enter the following command, replacing `KUBO-DEPLOYMENT-RELEASE-URL` with the name of the file you downloaded in the previous step:
+  <p class="terminal">$ tar -xvf $(basename `KUBO-DEPLOYMENT-RELEASE-URL`)</p>
+1. Change into the directory that contains the GCP Terraform templates. Enter the following command:
+	<p class="terminal">$ cd ~/$(basename `KUBO-DEPLOYMENT-RELEASE-URL` .tgz)/kubo-deployment/docs/terraform/gcp/platform</p>
+1. Initialize the Terraform cloud provider. Enter the following command:
+	<p class="terminal">$ docker run -i -t \
+  -v \$(pwd):/\$(basename \$(pwd)) \
+  -w /\$(basename $(pwd)) \
+  hashicorp/terraform:light init</p>
+1. Create the bastion and other resources. Enter the following command:
+	<p class="terminal">$ docker run -i -t \
+  -e CHECKPOINT_DISABLE=1 \
+  -e "GOOGLE_CREDENTIALS=\${GOOGLE_CREDENTIALS}" \
+  -v \$(pwd):/\$(basename \$(pwd)) \
+  -w /\$(basename \$(pwd)) \
+  hashicorp/terraform:light apply \
+    -var service_account_email=\${service_account_email} \
+    -var projectid=\${project_id} \
+    -var network=\${network} \
+    -var region=\${region} \
+    -var prefix=\${prefix:-cfcr} \
+    -var zone=\${zone} \
+    -var subnet_ip_prefix=\${subnet_ip_prefix} \
+    -state /\$(basename \$(pwd))/${prefix:-cfcr}.tfstate
+	</p>
+	This command takes between 60 and 90 seconds to complete.
+
+	!!! tip
+		To preview the Terraform execution plan before applying it, run `plan` instead of `apply`.
+
+1. Copy the service account key to the newly created bastion VM. Enter the following command:
+	<p class="terminal">$ gcloud compute scp ~/\${prefix:-cfcr}-tf.key.json "\${prefix:-cfcr}-bosh-bastion":./terraform.key.json --zone \${zone}</p>
+	If prompted to create SSH keys, enter `Y` and use an empty passphrase.
+
+##Step 4: Generate BOSH Configuration
+
+Perform the following steps to generate the configuration for your BOSH Director:
+
+1. From the Google Cloud Shell, SSH onto the bastion VM. Enter the following command:
+	<p class="terminal">$ gcloud compute ssh "${prefix:-cfcr}-bosh-bastion" --zone ${zone}</p>
+1. Change into the root of the `kubo-deployment` repo. Enter the following command:
+	<p class="terminal">$ cd /share/kubo-deployment</p>
+1. Set three environment variables with the following commands:
+	<p class="terminal">$ export kubo_envs=~/kubo-env
+$ export kubo_env_name=kubo
+$ export kubo_env_path="\${kubo_envs}/\${kubo_env_name}"</p>
+
+	!!! note
+		`kubo_env_path` points to the directory containing the CFCR configuration. Later topics will refer to this path as `KUBO_ENV`.
+
+1. Make a new directory path with the following command:
+	<p class="terminal">$ mkdir -p "${kubo_envs}"</p>
+1. Generate a CFCR configuration template. Enter the following command:
+	<p class="terminal">$ ./bin/generate_env_config "${kubo_envs}" ${kubo_env_name} gcp</p>
+1. Execute the `update_gcp_env` script to apply the default network settings configured during the infrastructure paving to the template. Enter the following command:
+	<p class="terminal">$ /usr/bin/update_gcp_env "${kubo_env_path}/director.yml"</p>
+
+	!!! tip
+		You can directly edit the configuration file located at `${kubo_env_path}/director.yml`.
+
+If you plan to use IaaS routing for CFCR, continue to [Configure IaaS Routing for GCP](routing-gcp/).
+
+If you have configured Cloud Foundry routing, continue to [Deploying CFCR](../deploying-cfcr/).

--- a/docs/installing/gcp/routing-gcp.md
+++ b/docs/installing/gcp/routing-gcp.md
@@ -2,7 +2,7 @@
 
 This topic describes how to configure the Google Cloud Platform (GCP) load balancers to handle routing for Cloud Foundry Container Runtime (CFCR).
 
-Before completing the procedures in this topic, you must have performed the steps in [Deploying BOSH for CFCR on GCP](deploying-bosh-gcp/). After finishing this topic, continue to [Deploying CFCR](../deploying-cfcr/).
+Before completing the procedures in this topic, you must have performed the steps in [Paving Infrastructure on GCP](paving-infrastructure-gcp/). After finishing this topic, continue to [Deploying CFCR](../deploying-cfcr/).
 
 If you want to use Cloud Foundry for routing instead of IaaS load balancers, see the [Configuring Cloud Foundry Routing](../cf-routing/) topic.
 
@@ -14,11 +14,11 @@ If you want to use Cloud Foundry for routing instead of IaaS load balancers, see
 
 ##(Optional) Step 1: Set Up Your Environment
 
-If you are still working in the same Google Cloud Shell session from the [Deploying BOSH for CFCR on GCP](deploying-bosh-gcp/) topic, skip to [Step 2: Configure Load Balancers](#step-2-configure-load-balancers).
+If you are still working in the same Google Cloud Shell session from the [Paving Infrastructure on GCP](paving-infrastructure-gcp/) topic, skip to [Step 2: Deploy BOSH Director](#step-2-deploy-bosh-director).
 
 If you have started a new Google Cloud Shell session, perform the following steps:
 
-1. Set the prefix and zone from the [Step 1: Set Up Your Shell Environment](deploying-bosh-gcp/#step-1-set-up-your-shell-environment) section of the [Deploying BOSH for CFCR on GCP](https://docs-kubo.cfapps.io/installing/gcp/deploying-bosh-gcp/) topic as environment variables. For example:
+1. Set the prefix and zone from the [Step 1: Set Up Your Shell Environment](paving-infrastructure-gcp/#step-1-set-up-your-shell-environment) section of the [Paving Infrastructure on GCP](https://docs-kubo.cfapps.io/installing/gcp/paving-infrastructure-gcp/) topic as environment variables. For example:
 	<p class="terminal">$ export prefix=my-kubo
 $ export zone=us-west1-a
 $ export network=kubo-network


### PR DESCRIPTION
Unfortunately on further reading, the change in PR #41 required a bit more than just swapping the order of the existing documentation (such wishful thinking on my part!)

## The problem
- steps 1 to 4 from deploying-bosh-gcp have to happen before IaaS routing
- IaaS routing has to be created before bosh is deployed

## The solution
- I've split steps 1 to 4 of deploying-bosh-gcp into a new page, paving-infrastructure-gcp
- paving-infrastructure-gcp is now the first guide, prior to IaaS routing
- ensure hyperlinks point to the correct page (paving-infrastructure-gcp or deploying-bosh-gcp as appropriate)

## Further
Docs team, please could you proof-read and check the links work, etc.?

[#155936514]