### PR TITLE
Instruct to deploy_bosh to update cc:elb

### DIFF
--- a/docs/installing/aws/routing-aws.md
+++ b/docs/installing/aws/routing-aws.md
@@ -50,4 +50,7 @@ $ export kubernetes_master_host=\$(terraform output -state=${kubo_terraform_stat
 	!!! tip
 		You can also set the configuration manually by editing `KUBO_ENV/director.yml`.
 
+1. Update the BOSH director cloud configuration to use the new load balancer:
+    <p class="terminal">$ /share/kubo-deployment/bin/deploy_bosh "${kubo_env_path}" ~/deployer.pem</p>
+
 After configuring routing, continue to the [Deploying CFCR](../deploying-cfcr/) topic.


### PR DESCRIPTION
Closes https://github.com/cloudfoundry-incubator/kubo-deployment/issues/272

In comparing the approaches:

1. GCP requires the user to set this up prior to deploy: "Before completing the procedures in this topic, you must have performed the steps " - https://docs-cfcr.cfapps.io/installing/gcp/deploying-bosh-gcp/
2. AWS does not carry the same stanza, but also has 3 subdocuments instead of 4 which might be easier to manage

This is probably the easiest small fix while maybe a future effort to unify the number of steps across cloud providers is done.