### PR TITLE
Modify stemcell version

### DIFF
--- a/docs/overview/release-notes.md
+++ b/docs/overview/release-notes.md
@@ -65,7 +65,7 @@ The following table lists the component versions for CFCR v0.17.0:
   </tr>
   <tr>
     <td>Stemcell</td>
-    <td>3586.8</td>
+    <td>3586.16</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
CFCR v0.17.0 actually uses 3586.16
https://github.com/cloudfoundry-incubator/kubo-deployment/blob/v0.17.0/manifests/cfcr.yml#L26
