### PR TITLE
Update paving-infrastructure-gcp.md

### DIFF
--- a/docs/installing/gcp/paving-infrastructure-gcp.md
+++ b/docs/installing/gcp/paving-infrastructure-gcp.md
@@ -17,7 +17,7 @@ Perform the following steps to set up your Google Cloud Shell environment:
 		If you plan to use [Cloud Foundry to handle routing](../cf-routing/) for CFCR, do not create a new network. Instead, deploy CFCR in the same network as Cloud Foundry.
 
 1. Enter a name for your network, such as `kubo-network`.
-1. The form will force you to create a subnet for the VPC network. After the VPC has been created, you can delete this subnet.
+1. Click on the trash can at the top of the subnet form, it is not needed.
 1. Click **Create**.
 1. Open the Google Cloud Shell by clicking the `>_` icon in the upper right of the GCP Console.
 


### PR DESCRIPTION
The subnet form is not required. If you click on trash can at the top of the subnet form you don't need to fill it out.